### PR TITLE
Update install.js file for newest versions of nodejs

### DIFF
--- a/install.js
+++ b/install.js
@@ -25,7 +25,7 @@ function main() {
     var binBasePath = PATH.join(__dirname, "/bin");
     if (!EXISTS_SYNC(binBasePath)) {
         console.log("Creating directory ", binBasePath);
-        FS.mkdir(binBasePath, 0755, function(){});
+        FS.mkdir(binBasePath, 0755, function () {});
     } else {
         console.log("Directory exists at ", binBasePath);
     }

--- a/install.js
+++ b/install.js
@@ -25,7 +25,7 @@ function main() {
     var binBasePath = PATH.join(__dirname, "/bin");
     if (!EXISTS_SYNC(binBasePath)) {
         console.log("Creating directory ", binBasePath);
-        FS.mkdir(binBasePath, 0755);
+        FS.mkdir(binBasePath, 0755, function(){});
     } else {
         console.log("Directory exists at ", binBasePath);
     }


### PR DESCRIPTION
For prevent next error
```
TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
    at makeCallback (fs.js:137:11)
    at Object.mkdir (fs.js:719:14)
    at main (C:\Users\admin\Desktop\777\node_modules\gnu-tools\install.js:28:12)
    at Object.<anonymous> (C:\Users\admin\Desktop\777\node_modules\gnu-tools\install.js:228:5)
    at Module._compile (internal/modules/cjs/loader.js:688:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)
    at Module.load (internal/modules/cjs/loader.js:598:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
    at Function.Module._load (internal/modules/cjs/loader.js:529:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:741:12)
```